### PR TITLE
Add base transport key and sprite usage

### DIFF
--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -31,6 +31,7 @@ public abstract class SharedTransportSystem : EntitySystem
     {
         component.ItemContainer = _containers.EnsureContainer<Container>(uid, component.ItemContainerId);
         component.KeyContainer = _containers.EnsureContainer<ContainerSlot>(uid, component.KeyContainerId);
+        component.PassengerCount = 0;
     }
 
     private void OnStrapped(EntityUid uid, TransportComponent component, ref StrappedEvent args)
@@ -38,20 +39,15 @@ public abstract class SharedTransportSystem : EntitySystem
         if (args.Strap.Owner != uid)
             return;
 
-        // ensure we don't exceed the passenger limit
-        var count = 0;
-        foreach (var strap in EntityQuery<StrapComponent>(uid))
-            count += strap.BuckledEntities.Count;
-
-        if (count > component.MaxPassengers)
+        if (component.PassengerCount >= component.MaxPassengers)
         {
             _buckle.TryUnbuckle(args.Buckle.Owner, args.Buckle.Owner);
             return;
         }
 
-        var isDriverSeat = args.Strap.Owner == uid && args.Strap.Id == component.DriverStrapId;
+        component.PassengerCount++;
 
-        if (isDriverSeat)
+        if (component.Driver == null)
         {
             component.Driver = args.Buckle.Owner;
             if (HasValidKey(uid, component))
@@ -63,6 +59,8 @@ public abstract class SharedTransportSystem : EntitySystem
     {
         if (args.Strap.Owner != uid)
             return;
+
+        component.PassengerCount = Math.Max(0, component.PassengerCount - 1);
 
         if (component.Driver == args.Buckle.Owner)
         {

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -21,4 +21,35 @@ public abstract class SharedTransportSystem : EntitySystem
         component.ItemContainer = _containers.EnsureContainer<Container>(uid, component.ItemContainerId);
         component.KeyContainer = _containers.EnsureContainer<ContainerSlot>(uid, component.KeyContainerId);
     }
+
+    /// <summary>
+    ///     Checks whether the provided key entity can operate the specified transport.
+    /// </summary>
+    public bool IsKeyValid(EntityUid transport, EntityUid key, TransportComponent? transportComp = null,
+        TransportKeyComponent? keyComp = null)
+    {
+        if (!Resolve(transport, ref transportComp) || !Resolve(key, ref keyComp))
+            return false;
+
+        if (string.IsNullOrEmpty(transportComp.KeyId))
+            return true;
+
+        return transportComp.KeyId == keyComp.TransportId;
+    }
+
+    /// <summary>
+    ///     Returns true if the transport has a valid key inserted, or a key is not required.
+    /// </summary>
+    public bool HasValidKey(EntityUid transport, TransportComponent? comp = null)
+    {
+        if (!Resolve(transport, ref comp))
+            return false;
+
+        var key = comp.KeyContainer.ContainedEntity;
+
+        if (key == null)
+            return !comp.RequireKey;
+
+        return IsKeyValid(transport, key.Value, comp);
+    }
 }

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -5,6 +5,10 @@ using Robust.Shared.GameStates;
 using Content.Shared.Audio;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Movement.Components;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Interaction.Components;
 
 namespace Content.Shared.Transport;
 
@@ -17,6 +21,8 @@ public abstract class SharedTransportSystem : EntitySystem
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly SharedMoverController _mover = default!;
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
 
     public override void Initialize()
     {
@@ -50,7 +56,11 @@ public abstract class SharedTransportSystem : EntitySystem
         if (component.Driver == null)
         {
             component.Driver = args.Buckle.Owner;
-            if (HasValidKey(uid, component))
+
+            if (component.EngineOn && component.NeedsHands)
+                BlockHands(uid, component, args.Buckle.Owner);
+
+            if (component.EngineOn && HasValidKey(uid, component))
                 _mover.SetRelay(args.Buckle.Owner, uid);
         }
     }
@@ -64,6 +74,9 @@ public abstract class SharedTransportSystem : EntitySystem
 
         if (component.Driver == args.Buckle.Owner)
         {
+            if (component.NeedsHands)
+                FreeHands(args.Buckle.Owner, component);
+
             RemComp<RelayInputMoverComponent>(component.Driver.Value);
             component.Driver = null;
         }
@@ -80,7 +93,12 @@ public abstract class SharedTransportSystem : EntitySystem
             _ambientSound.SetAmbience(uid, true);
 
             if (component.Driver != null)
+            {
+                if (component.NeedsHands)
+                    BlockHands(uid, component, component.Driver.Value);
+
                 _mover.SetRelay(component.Driver.Value, uid);
+            }
         }
         else
         {
@@ -88,7 +106,12 @@ public abstract class SharedTransportSystem : EntitySystem
             _ambientSound.SetAmbience(uid, false);
 
             if (component.Driver != null)
+            {
+                if (component.NeedsHands)
+                    FreeHands(component.Driver.Value, component);
+
                 RemComp<RelayInputMoverComponent>(component.Driver.Value);
+            }
         }
     }
 
@@ -121,5 +144,54 @@ public abstract class SharedTransportSystem : EntitySystem
             return !comp.RequireKey;
 
         return IsKeyValid(transport, key.Value, comp);
+    }
+
+    private void BlockHands(EntityUid transport, TransportComponent comp, EntityUid driver)
+    {
+        if (!TryComp(driver, out HandsComponent? hands))
+            return;
+
+        var freeHands = 0;
+        foreach (var hand in _hands.EnumerateHands(driver, hands))
+        {
+            if (hand.HeldEntity == null)
+            {
+                freeHands++;
+                continue;
+            }
+
+            if (HasComp<UnremoveableComponent>(hand.HeldEntity) && hand.HeldEntity != driver)
+                continue;
+
+            _hands.DoDrop(driver, hand, true, hands);
+            freeHands++;
+            if (freeHands == 2)
+                break;
+        }
+
+        if (_virtualItem.TrySpawnVirtualItemInHand(transport, driver, out var item1, true))
+        {
+            EnsureComp<UnremoveableComponent>(item1.Value);
+            comp.HandVirtualItems.Add(item1.Value);
+        }
+
+        if (_virtualItem.TrySpawnVirtualItemInHand(transport, driver, out var item2, true))
+        {
+            EnsureComp<UnremoveableComponent>(item2.Value);
+            comp.HandVirtualItems.Add(item2.Value);
+        }
+    }
+
+    private void FreeHands(EntityUid driver, TransportComponent comp)
+    {
+        foreach (var item in comp.HandVirtualItems)
+        {
+            if (!TryComp(item, out VirtualItemComponent? virt))
+                continue;
+
+            _virtualItem.DeleteVirtualItem((item, virt), driver);
+        }
+
+        comp.HandVirtualItems.Clear();
     }
 }

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -17,7 +17,6 @@ public abstract class SharedTransportSystem : EntitySystem
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly SharedMoverController _mover = default!;
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -30,7 +29,6 @@ public abstract class SharedTransportSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, TransportComponent component, ComponentStartup args)
     {
-        component.PassengerContainer = _containers.EnsureContainer<Container>(uid, component.PassengerContainerId);
         component.ItemContainer = _containers.EnsureContainer<Container>(uid, component.ItemContainerId);
         component.KeyContainer = _containers.EnsureContainer<ContainerSlot>(uid, component.KeyContainerId);
     }
@@ -40,30 +38,24 @@ public abstract class SharedTransportSystem : EntitySystem
         if (args.Strap.Owner != uid)
             return;
 
-        if (component.PassengerContainer.ContainedEntities.Count >= component.MaxPassengers)
+        // ensure we don't exceed the passenger limit
+        var count = 0;
+        foreach (var strap in EntityQuery<StrapComponent>(uid))
+            count += strap.BuckledEntities.Count;
+
+        if (count > component.MaxPassengers)
         {
             _buckle.TryUnbuckle(args.Buckle.Owner, args.Buckle.Owner);
             return;
         }
 
-        _containers.Insert(args.Buckle.Owner, component.PassengerContainer);
+        var isDriverSeat = args.Strap.Owner == uid && args.Strap.Id == component.DriverStrapId;
 
-        var seatIndex = 0;
-        if (component.Driver == null)
+        if (isDriverSeat)
         {
             component.Driver = args.Buckle.Owner;
             if (HasValidKey(uid, component))
                 _mover.SetRelay(args.Buckle.Owner, uid);
-        }
-        else
-        {
-            seatIndex = 1;
-        }
-
-        if (seatIndex < component.SeatOffsets.Count)
-        {
-            var xform = Transform(args.Buckle.Owner);
-            xform.LocalPosition = component.SeatOffsets[seatIndex];
         }
     }
 
@@ -71,8 +63,6 @@ public abstract class SharedTransportSystem : EntitySystem
     {
         if (args.Strap.Owner != uid)
             return;
-
-        _containers.Remove(args.Buckle.Owner, component.PassengerContainer);
 
         if (component.Driver == args.Buckle.Owner)
         {

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -39,7 +39,7 @@ public abstract class SharedTransportSystem : EntitySystem
             return;
         }
 
-        component.PassengerContainer.Insert(args.Buckle.Owner);
+        _containers.Insert(args.Buckle.Owner, component.PassengerContainer);
         UpdateSeatPositions(uid, component);
     }
 
@@ -48,7 +48,7 @@ public abstract class SharedTransportSystem : EntitySystem
         if (args.Strap.Owner != uid)
             return;
 
-        component.PassengerContainer.Remove(args.Buckle.Owner);
+        _containers.Remove(args.Buckle.Owner, component.PassengerContainer);
         UpdateSeatPositions(uid, component);
     }
 

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using Content.Shared.Buckle;
+using Content.Shared.Buckle.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 
@@ -9,10 +12,13 @@ namespace Content.Shared.Transport;
 public abstract class SharedTransportSystem : EntitySystem
 {
     [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly SharedBuckleSystem _buckle = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<TransportComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<TransportComponent, StrappedEvent>(OnStrapped);
+        SubscribeLocalEvent<TransportComponent, UnstrappedEvent>(OnUnstrapped);
     }
 
     private void OnStartup(EntityUid uid, TransportComponent component, ComponentStartup args)
@@ -20,6 +26,41 @@ public abstract class SharedTransportSystem : EntitySystem
         component.PassengerContainer = _containers.EnsureContainer<Container>(uid, component.PassengerContainerId);
         component.ItemContainer = _containers.EnsureContainer<Container>(uid, component.ItemContainerId);
         component.KeyContainer = _containers.EnsureContainer<ContainerSlot>(uid, component.KeyContainerId);
+    }
+
+    private void OnStrapped(EntityUid uid, TransportComponent component, ref StrappedEvent args)
+    {
+        if (args.Strap.Owner != uid)
+            return;
+
+        if (component.PassengerContainer.ContainedEntities.Count >= component.MaxPassengers)
+        {
+            _buckle.TryUnbuckle(args.Buckle.Owner, args.Buckle.Owner);
+            return;
+        }
+
+        component.PassengerContainer.Insert(args.Buckle.Owner);
+        UpdateSeatPositions(uid, component);
+    }
+
+    private void OnUnstrapped(EntityUid uid, TransportComponent component, ref UnstrappedEvent args)
+    {
+        if (args.Strap.Owner != uid)
+            return;
+
+        component.PassengerContainer.Remove(args.Buckle.Owner);
+        UpdateSeatPositions(uid, component);
+    }
+
+    private void UpdateSeatPositions(EntityUid uid, TransportComponent component)
+    {
+        var i = 0;
+        foreach (var passenger in component.PassengerContainer.ContainedEntities)
+        {
+            var offset = i < component.SeatOffsets.Count ? component.SeatOffsets[i] : Vector2.Zero;
+            Transform(passenger).LocalPosition = offset;
+            i++;
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -2,6 +2,9 @@ using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Content.Shared.Audio;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Movement.Components;
 
 namespace Content.Shared.Transport;
 
@@ -12,12 +15,16 @@ public abstract class SharedTransportSystem : EntitySystem
 {
     [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
+    [Dependency] private readonly SharedMoverController _mover = default!;
+    [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<TransportComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<TransportComponent, StrappedEvent>(OnStrapped);
         SubscribeLocalEvent<TransportComponent, UnstrappedEvent>(OnUnstrapped);
+        SubscribeLocalEvent<TransportComponent, EntInsertedIntoContainerMessage>(OnContainerModified);
+        SubscribeLocalEvent<TransportComponent, EntRemovedFromContainerMessage>(OnContainerModified);
     }
 
     private void OnStartup(EntityUid uid, TransportComponent component, ComponentStartup args)
@@ -39,6 +46,13 @@ public abstract class SharedTransportSystem : EntitySystem
         }
 
         _containers.Insert(args.Buckle.Owner, component.PassengerContainer);
+
+        if (args.Strap.ID == component.DriverStrapId && component.Driver == null)
+        {
+            component.Driver = args.Buckle.Owner;
+            if (HasValidKey(uid, component))
+                _mover.SetRelay(args.Buckle.Owner, uid);
+        }
     }
 
     private void OnUnstrapped(EntityUid uid, TransportComponent component, ref UnstrappedEvent args)
@@ -47,6 +61,35 @@ public abstract class SharedTransportSystem : EntitySystem
             return;
 
         _containers.Remove(args.Buckle.Owner, component.PassengerContainer);
+
+        if (component.Driver == args.Buckle.Owner)
+        {
+            RemComp<RelayInputMoverComponent>(component.Driver.Value);
+            component.Driver = null;
+        }
+    }
+
+    private void OnContainerModified(EntityUid uid, TransportComponent component, ContainerModifiedMessage args)
+    {
+        if (args.Container.ID != component.KeyContainerId)
+            return;
+
+        if (component.KeyContainer.ContainedEntity != null)
+        {
+            component.EngineOn = true;
+            _ambientSound.SetAmbience(uid, true);
+
+            if (component.Driver != null)
+                _mover.SetRelay(component.Driver.Value, uid);
+        }
+        else
+        {
+            component.EngineOn = false;
+            _ambientSound.SetAmbience(uid, false);
+
+            if (component.Driver != null)
+                RemComp<RelayInputMoverComponent>(component.Driver.Value);
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -60,7 +60,7 @@ public abstract class SharedTransportSystem : EntitySystem
             if (component.EngineOn && component.NeedsHands)
                 BlockHands(uid, component, args.Buckle.Owner);
 
-            if (component.EngineOn && HasValidKey(uid, component))
+            if (HasValidKey(uid, component))
                 _mover.SetRelay(args.Buckle.Owner, uid);
         }
     }

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
 using Robust.Shared.Containers;
@@ -40,7 +39,6 @@ public abstract class SharedTransportSystem : EntitySystem
         }
 
         _containers.Insert(args.Buckle.Owner, component.PassengerContainer);
-        UpdateSeatPositions(uid, component);
     }
 
     private void OnUnstrapped(EntityUid uid, TransportComponent component, ref UnstrappedEvent args)
@@ -49,18 +47,6 @@ public abstract class SharedTransportSystem : EntitySystem
             return;
 
         _containers.Remove(args.Buckle.Owner, component.PassengerContainer);
-        UpdateSeatPositions(uid, component);
-    }
-
-    private void UpdateSeatPositions(EntityUid uid, TransportComponent component)
-    {
-        var i = 0;
-        foreach (var passenger in component.PassengerContainer.ContainedEntities)
-        {
-            var offset = i < component.SeatOffsets.Count ? component.SeatOffsets[i] : Vector2.Zero;
-            Transform(passenger).LocalPosition = offset;
-            i++;
-        }
     }
 
     /// <summary>

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Transport;
+
+/// <summary>
+///     Handles common initialization for <see cref="TransportComponent"/>.
+/// </summary>
+public abstract class SharedTransportSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TransportComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, TransportComponent component, ComponentStartup args)
+    {
+        component.PassengerContainer = _containers.EnsureContainer<Container>(uid, component.PassengerContainerId);
+        component.ItemContainer = _containers.EnsureContainer<Container>(uid, component.ItemContainerId);
+        component.KeyContainer = _containers.EnsureContainer<ContainerSlot>(uid, component.KeyContainerId);
+    }
+}

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -17,6 +17,7 @@ public abstract class SharedTransportSystem : EntitySystem
     [Dependency] private readonly SharedBuckleSystem _buckle = default!;
     [Dependency] private readonly SharedMoverController _mover = default!;
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -47,11 +48,22 @@ public abstract class SharedTransportSystem : EntitySystem
 
         _containers.Insert(args.Buckle.Owner, component.PassengerContainer);
 
+        var seatIndex = 0;
         if (component.Driver == null)
         {
             component.Driver = args.Buckle.Owner;
             if (HasValidKey(uid, component))
                 _mover.SetRelay(args.Buckle.Owner, uid);
+        }
+        else
+        {
+            seatIndex = 1;
+        }
+
+        if (seatIndex < component.SeatOffsets.Count)
+        {
+            var xform = Transform(args.Buckle.Owner);
+            xform.LocalPosition = component.SeatOffsets[seatIndex];
         }
     }
 

--- a/Content.Shared/Transport/Systems/SharedTransportSystem.cs
+++ b/Content.Shared/Transport/Systems/SharedTransportSystem.cs
@@ -47,7 +47,7 @@ public abstract class SharedTransportSystem : EntitySystem
 
         _containers.Insert(args.Buckle.Owner, component.PassengerContainer);
 
-        if (args.Strap.ID == component.DriverStrapId && component.Driver == null)
+        if (component.Driver == null)
         {
             component.Driver = args.Buckle.Owner;
             if (HasValidKey(uid, component))

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Containers;
+using System.Numerics;
 
 namespace Content.Shared.Transport;
 
@@ -14,6 +15,13 @@ public sealed partial class TransportComponent : Component
     /// </summary>
     [DataField]
     public int MaxPassengers = 1;
+
+    /// <summary>
+    /// Local offsets for each seat relative to the transport's origin. The first
+    /// offset is used for the driver seat.
+    /// </summary>
+    [DataField]
+    public List<Vector2> SeatOffsets = new();
 
     /// <summary>
     /// Maximum number of items that can be stored in this transport.

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -50,4 +50,22 @@ public sealed partial class TransportComponent : Component
 
     [DataField]
     public string KeyContainerId = "key_slot";
+
+    /// <summary>
+    /// Identifier of the strap that represents the driver seat.
+    /// </summary>
+    [DataField]
+    public string DriverStrapId = "driverSeat";
+
+    /// <summary>
+    /// The entity currently driving the transport.
+    /// </summary>
+    [ViewVariables]
+    public EntityUid? Driver;
+
+    /// <summary>
+    /// Whether the engine is currently running.
+    /// </summary>
+    [ViewVariables]
+    public bool EngineOn;
 }

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Robust.Shared.GameStates;
 using Robust.Shared.Containers;
 
@@ -50,4 +51,11 @@ public sealed partial class TransportComponent : Component
 
     [DataField]
     public string KeyContainerId = "key";
+
+    /// <summary>
+    /// Offsets, relative to the transport's position, for each seat.
+    /// Buckled passengers will be moved to these positions in order of seating.
+    /// </summary>
+    [DataField]
+    public List<Vector2> SeatOffsets = new();
 }

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -1,0 +1,47 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Containers;
+
+namespace Content.Shared.Transport;
+
+/// <summary>
+/// Base component for generic transport entities that can hold passengers and items.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TransportComponent : Component
+{
+    /// <summary>
+    /// Maximum number of passenger entities that can occupy this transport.
+    /// </summary>
+    [DataField]
+    public int MaxPassengers = 1;
+
+    /// <summary>
+    /// Maximum number of items that can be stored in this transport.
+    /// </summary>
+    [DataField]
+    public int MaxItemSlots = 0;
+
+    /// <summary>
+    /// Whether an ignition key is required for operation.
+    /// </summary>
+    [DataField]
+    public bool RequireKey = true;
+
+    [ViewVariables]
+    public Container PassengerContainer = default!;
+
+    [ViewVariables]
+    public Container ItemContainer = default!;
+
+    [ViewVariables]
+    public ContainerSlot KeyContainer = default!;
+
+    [DataField]
+    public string PassengerContainerId = "passengers";
+
+    [DataField]
+    public string ItemContainerId = "storage";
+
+    [DataField]
+    public string KeyContainerId = "key";
+}

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -66,6 +66,18 @@ public sealed partial class TransportComponent : Component
     public bool EngineOn;
 
     /// <summary>
+    ///     Whether the driver must have free hands while operating.
+    /// </summary>
+    [DataField]
+    public bool NeedsHands = true;
+
+    /// <summary>
+    ///     Virtual items occupying the driver's hands while driving.
+    /// </summary>
+    [ViewVariables]
+    public List<EntityUid> HandVirtualItems = new();
+
+    /// <summary>
     /// Current number of passengers buckled into the transport.
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -27,6 +27,12 @@ public sealed partial class TransportComponent : Component
     [DataField]
     public bool RequireKey = true;
 
+    /// <summary>
+    /// Identifier of the key required to operate this transport.
+    /// </summary>
+    [DataField]
+    public string? KeyId;
+
     [ViewVariables]
     public Container PassengerContainer = default!;
 

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -1,6 +1,5 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Containers;
-using System.Numerics;
 
 namespace Content.Shared.Transport;
 
@@ -11,17 +10,11 @@ namespace Content.Shared.Transport;
 public sealed partial class TransportComponent : Component
 {
     /// <summary>
-    /// Maximum number of passenger entities that can occupy this transport.
+    /// Maximum number of passenger entities that can occupy this transport,
+    /// including the driver.
     /// </summary>
     [DataField]
     public int MaxPassengers = 1;
-
-    /// <summary>
-    /// Local offsets for each seat relative to the transport's origin. The first
-    /// offset is used for the driver seat.
-    /// </summary>
-    [DataField]
-    public List<Vector2> SeatOffsets = new();
 
     /// <summary>
     /// Maximum number of items that can be stored in this transport.
@@ -42,16 +35,11 @@ public sealed partial class TransportComponent : Component
     public string? KeyId;
 
     [ViewVariables]
-    public Container PassengerContainer = default!;
-
-    [ViewVariables]
     public Container ItemContainer = default!;
 
     [ViewVariables]
     public ContainerSlot KeyContainer = default!;
 
-    [DataField]
-    public string PassengerContainerId = "passengers";
 
     [DataField]
     public string ItemContainerId = "storage";

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Robust.Shared.GameStates;
 using Robust.Shared.Containers;
 
@@ -50,12 +49,5 @@ public sealed partial class TransportComponent : Component
     public string ItemContainerId = "storage";
 
     [DataField]
-    public string KeyContainerId = "key";
-
-    /// <summary>
-    /// Offsets, relative to the transport's position, for each seat.
-    /// Buckled passengers will be moved to these positions in order of seating.
-    /// </summary>
-    [DataField]
-    public List<Vector2> SeatOffsets = new();
+    public string KeyContainerId = "key_slot";
 }

--- a/Content.Shared/Transport/TransportComponent.cs
+++ b/Content.Shared/Transport/TransportComponent.cs
@@ -64,4 +64,10 @@ public sealed partial class TransportComponent : Component
     /// </summary>
     [ViewVariables]
     public bool EngineOn;
+
+    /// <summary>
+    /// Current number of passengers buckled into the transport.
+    /// </summary>
+    [ViewVariables]
+    public int PassengerCount;
 }

--- a/Content.Shared/Transport/TransportKeyComponent.cs
+++ b/Content.Shared/Transport/TransportKeyComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Transport;
+
+/// <summary>
+/// Component placed on transport ignition keys to mark which transports they can operate.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TransportKeyComponent : Component
+{
+    /// <summary>
+    /// Identifier matching <see cref="TransportComponent.KeyId"/>.
+    /// </summary>
+    [DataField]
+    public string TransportId = string.Empty;
+}

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -7,18 +7,17 @@
     maxPassengers: 2
     maxItemSlots: 0
     requireKey: true
+    seatOffsets:
+    - "0,0.15"
+    - "0,-0.15"
   - type: Sprite
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
     noRot: true
   - type: Strap
-    id: driverSeat
+    id: seat
     position: Stand
-    buckleOffset: "0,0.15"
-  - type: Strap
-    id: passengerSeat
-    position: Stand
-    buckleOffset: "0,-0.15"
+    size: 200
 - type: entity
   id: TransportCart
   parent: BaseTransport

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: BaseTransport
+  abstract: true
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Transport
+    maxPassengers: 1
+    maxItemSlots: 0
+    requireKey: true
+  - type: Sprite
+    sprite: Objects/Vehicles/atv.rsi
+    state: vehicle
+    noRot: true

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -7,17 +7,35 @@
     maxPassengers: 2
     maxItemSlots: 0
     requireKey: true
-    seatOffsets:
-    - "0,0.15"
-    - "0,-0.15"
   - type: Sprite
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
     noRot: true
+  - type: Pullable
+  - type: Clickable
+  - type: InteractionOutline
+  - type: ItemSlots
+    slots:
+      key_slot:
+        name: vehicle-slot-component-slot-name-keys
+        whitelist:
+          requireAll: true
+          tags:
+          - TransportKey
+        insertSound:
+          path: /Audio/Effects/Vehicle/vehiclestartup.ogg
+          params:
+            volume: -3
   - type: Strap
-    id: seat
+    id: driverSeat
     position: Stand
-    size: 200
+    size: 100
+    buckleOffset: "0,0.15"
+  - type: Strap
+    id: passengerSeat
+    position: Stand
+    size: 100
+    buckleOffset: "0,-0.15"
 - type: entity
   id: TransportCart
   parent: BaseTransport

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -4,7 +4,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Transport
-    maxPassengers: 1
+    maxPassengers: 2
     maxItemSlots: 0
     requireKey: true
   - type: Sprite
@@ -55,6 +55,12 @@
     id: driverSeat
     position: Stand
     size: 100
+    buckleOffset: "-0.15,0"
+  - type: Strap
+    id: passengerSeat
+    position: Stand
+    size: 100
+    buckleOffset: "0.15,0"
 - type: entity
   id: TransportCart
   parent: BaseTransport

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -11,6 +11,31 @@
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
     noRot: true
+  - type: AmbientSound
+    sound: /Audio/Effects/Vehicle/vehicleengineidle.ogg
+    range: 8
+    volume: -6
+    enabled: false
+  - type: InputMover
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      base:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 100
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+        hard: true
+  - type: MovementSpeedModifier
+    acceleration: 8
+    friction: 5
+    baseSprintSpeed: 6
+    baseWalkSpeed: 4.5
   - type: Pullable
   - type: Clickable
   - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -22,3 +22,6 @@
   parent: BaseTransport
   name: cart
   description: A simple two-seat transport.
+  components:
+  - type: Transport
+    keyId: cart

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -17,3 +17,8 @@
   - type: Strap
     position: Stand
     buckleOffset: "0,-0.15"
+- type: entity
+  id: TransportCart
+  parent: BaseTransport
+  name: cart
+  description: A simple two-seat transport.

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -7,9 +7,6 @@
     maxPassengers: 2
     maxItemSlots: 0
     requireKey: true
-    seatOffsets:
-      - "-0.15,0"
-      - "0.15,0"
   - type: Sprite
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
@@ -58,6 +55,12 @@
     id: driverSeat
     position: Stand
     size: 200
+    buckleOffset: "-0.15,0"
+  - type: Strap
+    id: passengerSeat
+    position: Stand
+    size: 200
+    buckleOffset: "0.15,0"
 - type: entity
   id: TransportCart
   parent: BaseTransport

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -7,6 +7,9 @@
     maxPassengers: 2
     maxItemSlots: 0
     requireKey: true
+    seatOffsets:
+      - "-0.15,0"
+      - "0.15,0"
   - type: Sprite
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
@@ -54,13 +57,7 @@
   - type: Strap
     id: driverSeat
     position: Stand
-    size: 100
-    buckleOffset: "-0.15,0"
-  - type: Strap
-    id: passengerSeat
-    position: Stand
-    size: 100
-    buckleOffset: "0.15,0"
+    size: 200
 - type: entity
   id: TransportCart
   parent: BaseTransport

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -12,9 +12,11 @@
     state: vehicle
     noRot: true
   - type: Strap
+    id: driverSeat
     position: Stand
     buckleOffset: "0,0.15"
   - type: Strap
+    id: passengerSeat
     position: Stand
     buckleOffset: "0,-0.15"
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -4,10 +4,16 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Transport
-    maxPassengers: 1
+    maxPassengers: 2
     maxItemSlots: 0
     requireKey: true
   - type: Sprite
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
     noRot: true
+  - type: Strap
+    position: Stand
+    buckleOffset: "0,0.15"
+  - type: Strap
+    position: Stand
+    buckleOffset: "0,-0.15"

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport.yml
@@ -4,7 +4,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Transport
-    maxPassengers: 2
+    maxPassengers: 1
     maxItemSlots: 0
     requireKey: true
   - type: Sprite
@@ -30,17 +30,11 @@
     id: driverSeat
     position: Stand
     size: 100
-    buckleOffset: "0,0.15"
-  - type: Strap
-    id: passengerSeat
-    position: Stand
-    size: 100
-    buckleOffset: "0,-0.15"
 - type: entity
   id: TransportCart
   parent: BaseTransport
   name: cart
-  description: A simple two-seat transport.
+  description: A simple transport.
   components:
   - type: Transport
     keyId: cart

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport_key.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport_key.yml
@@ -12,3 +12,4 @@
   - type: Sprite
     sprite: Objects/Vehicles/atv.rsi
     state: keys
+  - type: TransportKey

--- a/Resources/Prototypes/Entities/Objects/Vehicles/base_transport_key.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/base_transport_key.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: BaseTransportKey
+  parent: BaseItem
+  abstract: true
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Item
+    size: Tiny
+  - type: Tag
+    tags:
+    - TransportKey
+  - type: Sprite
+    sprite: Objects/Vehicles/atv.rsi
+    state: keys

--- a/Resources/Prototypes/Entities/Objects/Vehicles/transport_cart_key.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/transport_cart_key.yml
@@ -1,0 +1,11 @@
+- type: entity
+  id: TransportCartKey
+  parent: BaseTransportKey
+  name: cart keys
+  description: Keys for a simple cart.
+  components:
+  - type: Sprite
+    sprite: Objects/Vehicles/atv.rsi
+    state: keys
+  - type: TransportKey
+    transportId: cart

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1432,6 +1432,9 @@
   id: VehicleKey
 
 - type: Tag
+  id: TransportKey
+
+- type: Tag
   id: VimPilot
 
 - type: Tag


### PR DESCRIPTION
## Summary
- add sprite details to `BaseTransport` prototype
- create a `BaseTransportKey` prototype with sprite setup

## Testing
- `dotnet --version` *(fails: `dotnet: command not found`)*
- `dotnet build Content.Shared/Content.Shared.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68493b30a2d0832d9335e28df1aaefc8