### PR TITLE
Add grid atmos fixer component

### DIFF
--- a/Content.Server/Atmos/Components/FixGridAtmosOnRoundStartComponent.cs
+++ b/Content.Server/Atmos/Components/FixGridAtmosOnRoundStartComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Atmos.Components;
+
+/// <summary>
+/// When present on an entity, triggers the fixgridatmos command for its grid when the round starts.
+/// Useful for ensuring standard atmosphere on round start during testing or mapping.
+/// </summary>
+[RegisterComponent]
+public sealed partial class FixGridAtmosOnRoundStartComponent : Component
+{
+}

--- a/Content.Server/Atmos/EntitySystems/FixGridAtmosOnRoundStartSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FixGridAtmosOnRoundStartSystem.cs
@@ -1,0 +1,37 @@
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Events;
+using Content.Server.Atmos.Components;
+using Robust.Shared.Console;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+/// <summary>
+/// Executes the fixgridatmos console command for any entity with
+/// <see cref="FixGridAtmosOnRoundStartComponent"/> when a round starts.
+/// </summary>
+public sealed partial class FixGridAtmosOnRoundStartSystem : EntitySystem
+{
+    [Dependency] private readonly IConsoleHost _consoleHost = default!;
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
+    }
+
+    private void OnRoundStarted(RoundStartedEvent ev)
+    {
+        var query = AllEntityQuery<FixGridAtmosOnRoundStartComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            if (xform.GridUid is not { } grid)
+                continue;
+
+            if (!_entities.TryGetNetEntity(grid, out var netGrid))
+                continue;
+
+            _consoleHost.ExecuteCommand($"fixgridatmos {netGrid.Value.Id}");
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Markers/atmos_roundstart_fix.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_roundstart_fix.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: AtmosRoundStartFixer
+  name: RoundStart Atmos Fixer
+  description: Runs fixgridatmos for this grid on round start
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    sprite: Markers/cross.rsi
+    state: green
+  - type: FixGridAtmosOnRoundStart


### PR DESCRIPTION
## Summary
- add a component and system that runs `fixgridatmos` on round start
- add a marker prototype using the component

## Testing
- `Scripts/sh/runTests.sh` *(fails: mkdir Scripts/logs: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684d6af7da9c832dbc5463e1e30b7770