### PR TITLE
Add client light filter component

### DIFF
--- a/Content.Client/_White/Light/DirectionalLightFilterSystem.cs
+++ b/Content.Client/_White/Light/DirectionalLightFilterSystem.cs
@@ -1,0 +1,64 @@
+using System.Numerics;
+using Content.Client.Overlays;
+using Content.Shared._White.Light;
+using Content.Shared._White.Light.Components;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Maths;
+
+namespace Content.Client._White.Light;
+
+public sealed class DirectionalLightFilterSystem : SharedDirectionalLightFilterSystem
+{
+    [Dependency] private readonly IPlayerManager _playerMan = default!;
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly IEntityManager _entMan = default!;
+
+    private ColorTintOverlay _overlay = default!;
+    private EntityQuery<DirectionalLightFilterComponent, TransformComponent> _query;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _query = GetEntityQuery<DirectionalLightFilterComponent, TransformComponent>();
+        _overlay = new ColorTintOverlay
+        {
+            TintColor = Vector3.Zero,
+            TintAmount = 0f
+        };
+        _overlayMan.AddOverlay(_overlay);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+        var player = _playerMan.LocalEntity;
+        if (player == null)
+        {
+            _overlay.TintAmount = 0f;
+            return;
+        }
+
+        var playerPos = _entMan.GetComponent<TransformComponent>(player.Value).WorldPosition;
+        var block = 0f;
+
+        foreach (var (comp, xform) in _query)
+        {
+            var diff = playerPos - xform.WorldPosition;
+            if (diff == Vector2.Zero)
+                continue;
+
+            var normal = (xform.WorldRotation + comp.BlockAngle).RotateVec(Vector2.UnitX);
+            if (Vector2.Dot(diff, normal) > 0f)
+                block = MathF.Max(block, comp.BlockFraction);
+        }
+
+        _overlay.TintAmount = block;
+    }
+}

--- a/Content.Client/_White/Light/DirectionalLightFilterSystem.cs
+++ b/Content.Client/_White/Light/DirectionalLightFilterSystem.cs
@@ -15,12 +15,10 @@ public sealed class DirectionalLightFilterSystem : SharedDirectionalLightFilterS
     [Dependency] private readonly IEntityManager _entMan = default!;
 
     private ColorTintOverlay _overlay = default!;
-    private EntityQuery<DirectionalLightFilterComponent, TransformComponent> _query;
 
     public override void Initialize()
     {
         base.Initialize();
-        _query = GetEntityQuery<DirectionalLightFilterComponent, TransformComponent>();
         _overlay = new ColorTintOverlay
         {
             TintColor = Vector3.Zero,
@@ -48,7 +46,7 @@ public sealed class DirectionalLightFilterSystem : SharedDirectionalLightFilterS
         var playerPos = _entMan.GetComponent<TransformComponent>(player.Value).WorldPosition;
         var block = 0f;
 
-        foreach (var (comp, xform) in _query)
+        foreach (var (comp, xform) in EntityManager.EntityQuery<DirectionalLightFilterComponent, TransformComponent>())
         {
             var diff = playerPos - xform.WorldPosition;
             if (diff == Vector2.Zero)

--- a/Content.Shared/_White/Light/Components/DirectionalLightFilterComponent.cs
+++ b/Content.Shared/_White/Light/Components/DirectionalLightFilterComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Maths;
+
+namespace Content.Shared._White.Light.Components;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class DirectionalLightFilterComponent : Component
+{
+    /// <summary>
+    /// Direction relative to the entity's rotation that will block light.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public Angle BlockAngle = Angle.Zero;
+
+    /// <summary>
+    /// Fraction of light blocked when viewed from the blocked direction (0-1).
+    /// 1 means fully blocked, 0 means fully pass through.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public float BlockFraction = 1f;
+}

--- a/Content.Shared/_White/Light/SharedDirectionalLightFilterSystem.cs
+++ b/Content.Shared/_White/Light/SharedDirectionalLightFilterSystem.cs
@@ -1,0 +1,5 @@
+namespace Content.Shared._White.Light;
+
+public abstract class SharedDirectionalLightFilterSystem : EntitySystem
+{
+}


### PR DESCRIPTION
## Summary
- add DirectionalLightFilterComponent for one-way light blocking
- add client system to darken the screen if viewing from the blocked side

## Testing
- `sh runTests.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea15efe00832d8c1295e5050b48af